### PR TITLE
feat: Implementa CRUD de Paciente e padronizacoes da API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/vollmed/api/controllers/MedicoController.java
+++ b/src/main/java/com/vollmed/api/controllers/MedicoController.java
@@ -29,7 +29,7 @@ public class MedicoController {
 
     @PutMapping
     @Transactional
-    public void atualizarMedico(@RequestBody @Valid DadosAtualizacaoMedico dados){
+    public void atualizarMedico(@RequestBody @Valid DadosAtualizacaoMedico dados) {
         var medico = medicoRepository.getReferenceById(dados.id());
         medico.atualizarInformacoesMedico(dados);
     }

--- a/src/main/java/com/vollmed/api/controllers/MedicoController.java
+++ b/src/main/java/com/vollmed/api/controllers/MedicoController.java
@@ -53,4 +53,10 @@ public class MedicoController {
 
         return ResponseEntity.noContent(). build();
     }
+
+    @GetMapping("/{id}")
+    public ResponseEntity detalharMedico(@PathVariable Long id) {
+        var medico = medicoRepository.getReferenceById(id);
+        return ResponseEntity.ok(new DadosDetalhamentoMedico(medico));
+    }
 }

--- a/src/main/java/com/vollmed/api/controllers/PacienteController.java
+++ b/src/main/java/com/vollmed/api/controllers/PacienteController.java
@@ -1,9 +1,6 @@
 package com.vollmed.api.controllers;
 
-import com.vollmed.api.paciente.DadosCadastroPaciente;
-import com.vollmed.api.paciente.DadosListagemPaciente;
-import com.vollmed.api.paciente.Paciente;
-import com.vollmed.api.paciente.PacienteRepository;
+import com.vollmed.api.paciente.*;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,5 +25,12 @@ public class PacienteController {
     @GetMapping
     public Page<DadosListagemPaciente> listarPacientes (@PageableDefault(size = 10, sort = "nome")Pageable paginacao) {
        return pacienteRepository.findByAtivoTrue(paginacao).map(DadosListagemPaciente::new);
+    }
+
+    @PutMapping
+    @Transactional
+    public void atualizarPaciente(@RequestBody @Valid DadosAtualizacaoPaciente dados) {
+        var patciente = pacienteRepository.getReferenceById(dados.id());
+        patciente.atualizarInformacoesPaciente(dados);
     }
 }

--- a/src/main/java/com/vollmed/api/controllers/PacienteController.java
+++ b/src/main/java/com/vollmed/api/controllers/PacienteController.java
@@ -1,15 +1,16 @@
 package com.vollmed.api.controllers;
 
 import com.vollmed.api.paciente.DadosCadastroPaciente;
+import com.vollmed.api.paciente.DadosListagemPaciente;
 import com.vollmed.api.paciente.Paciente;
 import com.vollmed.api.paciente.PacienteRepository;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("pacientes")
@@ -22,5 +23,10 @@ public class PacienteController {
     @Transactional
     public void cadastrarPaciente(@RequestBody @Valid DadosCadastroPaciente dados) {
         pacienteRepository.save(new Paciente(dados));
+    }
+
+    @GetMapping
+    public Page<DadosListagemPaciente> listarPacientes (@PageableDefault(size = 10, sort = "nome")Pageable paginacao) {
+       return pacienteRepository.findByAtivoTrue(paginacao).map(DadosListagemPaciente::new);
     }
 }

--- a/src/main/java/com/vollmed/api/controllers/PacienteController.java
+++ b/src/main/java/com/vollmed/api/controllers/PacienteController.java
@@ -33,4 +33,11 @@ public class PacienteController {
         var patciente = pacienteRepository.getReferenceById(dados.id());
         patciente.atualizarInformacoesPaciente(dados);
     }
+
+    @DeleteMapping("/{id}")
+    @Transactional
+    public void excluirPaciente(@PathVariable Long id) {
+        var paciente = pacienteRepository.getReferenceById(id);
+        paciente.excluirPaciente();
+    }
 }

--- a/src/main/java/com/vollmed/api/controllers/PacienteController.java
+++ b/src/main/java/com/vollmed/api/controllers/PacienteController.java
@@ -1,0 +1,26 @@
+package com.vollmed.api.controllers;
+
+import com.vollmed.api.paciente.DadosCadastroPaciente;
+import com.vollmed.api.paciente.Paciente;
+import com.vollmed.api.paciente.PacienteRepository;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("pacientes")
+public class PacienteController {
+
+    @Autowired
+    private PacienteRepository pacienteRepository;
+
+    @PostMapping
+    @Transactional
+    public void cadastrarPaciente(@RequestBody @Valid DadosCadastroPaciente dados) {
+        pacienteRepository.save(new Paciente(dados));
+    }
+}

--- a/src/main/java/com/vollmed/api/medico/DadosDetalhamentoMedico.java
+++ b/src/main/java/com/vollmed/api/medico/DadosDetalhamentoMedico.java
@@ -1,0 +1,16 @@
+package com.vollmed.api.medico;
+
+import com.vollmed.api.endereco.Endereco;
+
+public record DadosDetalhamentoMedico(
+        Long id,
+        String nome,
+        String crm,
+        String telefone,
+        String medicoTelefone, Especialidade especialidade,
+        Endereco endereco) {
+
+    public DadosDetalhamentoMedico (Medico medico) {
+        this(medico.getId(), medico.getNome(), medico.getEmail(), medico.getCrm(), medico.getTelefone(), medico.getEspecialidade(), medico.getEndereco());
+    }
+}

--- a/src/main/java/com/vollmed/api/paciente/DadosAtualizacaoPaciente.java
+++ b/src/main/java/com/vollmed/api/paciente/DadosAtualizacaoPaciente.java
@@ -1,0 +1,12 @@
+package com.vollmed.api.paciente;
+
+import com.vollmed.api.endereco.DadosEndereco;
+import jakarta.validation.constraints.NotNull;
+
+public record DadosAtualizacaoPaciente(
+        @NotNull
+        Long id,
+        String nome,
+        String telefone,
+        DadosEndereco endereco) {
+}

--- a/src/main/java/com/vollmed/api/paciente/DadosCadastroPaciente.java
+++ b/src/main/java/com/vollmed/api/paciente/DadosCadastroPaciente.java
@@ -1,0 +1,28 @@
+package com.vollmed.api.paciente;
+
+import com.vollmed.api.endereco.DadosEndereco;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import org.hibernate.validator.constraints.br.CPF;
+
+public record DadosCadastroPaciente(
+
+        @NotBlank
+        String nome,
+
+        @NotBlank @Email
+        String email,
+
+        @NotBlank @CPF
+        @Pattern(regexp = "\\d{3}\\.\\d{3}\\.\\d{3}\\-\\d{2}")
+        String cpf,
+
+        @NotBlank
+        String telefone,
+
+        @NotNull @Valid
+        DadosEndereco endereco) {
+}

--- a/src/main/java/com/vollmed/api/paciente/DadosListagemPaciente.java
+++ b/src/main/java/com/vollmed/api/paciente/DadosListagemPaciente.java
@@ -1,0 +1,13 @@
+package com.vollmed.api.paciente;
+
+public record DadosListagemPaciente(
+        Long id,
+        String name,
+        String email,
+        String cpf
+) {
+
+    public DadosListagemPaciente(Paciente paciente) {
+        this(paciente.getId(), paciente.getNome(), paciente.getEmail(), paciente.getCpf());
+    }
+}

--- a/src/main/java/com/vollmed/api/paciente/Paciente.java
+++ b/src/main/java/com/vollmed/api/paciente/Paciente.java
@@ -2,6 +2,7 @@ package com.vollmed.api.paciente;
 
 import com.vollmed.api.endereco.Endereco;
 import jakarta.persistence.*;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -32,5 +33,18 @@ public class Paciente {
         this.cpf = dados.cpf();
         this.endereco = new Endereco(dados.endereco());
         this.ativo = true;
+    }
+
+    public void atualizarInformacoesPaciente(@Valid DadosAtualizacaoPaciente dados) {
+        if (dados.nome() != null) {
+            this.nome = dados.nome();
+        }
+        if (dados.telefone() != null) {
+            this.telefone = dados.telefone();
+        }
+        if (dados.endereco() != null) {
+            this.endereco.atualizarInformacoesEndereco(dados.endereco());
+        }
+
     }
 }

--- a/src/main/java/com/vollmed/api/paciente/Paciente.java
+++ b/src/main/java/com/vollmed/api/paciente/Paciente.java
@@ -1,0 +1,36 @@
+package com.vollmed.api.paciente;
+
+import com.vollmed.api.endereco.Endereco;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "Paciente")
+@Table(name = "pacientes")
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class Paciente {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nome;
+    private String email;
+    private String telefone;
+    private String cpf;
+    private Boolean ativo;
+
+    @Embedded
+    private Endereco endereco;
+
+    public Paciente( DadosCadastroPaciente dados) {
+        this.nome = dados.nome();
+        this.email = dados.email();
+        this.telefone = dados.telefone();
+        this.cpf = dados.cpf();
+        this.endereco = new Endereco(dados.endereco());
+        this.ativo = true;
+    }
+}

--- a/src/main/java/com/vollmed/api/paciente/Paciente.java
+++ b/src/main/java/com/vollmed/api/paciente/Paciente.java
@@ -47,4 +47,8 @@ public class Paciente {
         }
 
     }
+
+    public void excluirPaciente() {
+        this.ativo = false;
+    }
 }

--- a/src/main/java/com/vollmed/api/paciente/PacienteRepository.java
+++ b/src/main/java/com/vollmed/api/paciente/PacienteRepository.java
@@ -1,8 +1,14 @@
 package com.vollmed.api.paciente;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface PacienteRepository extends JpaRepository<Paciente, Long> {
+
+    Page<Paciente> findByAtivoTrue(Pageable paginacao);
 }

--- a/src/main/java/com/vollmed/api/paciente/PacienteRepository.java
+++ b/src/main/java/com/vollmed/api/paciente/PacienteRepository.java
@@ -1,0 +1,8 @@
+package com.vollmed.api.paciente;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PacienteRepository extends JpaRepository<Paciente, Long> {
+}

--- a/src/main/resources/db/migration/V4__create-table-pacientes.sql
+++ b/src/main/resources/db/migration/V4__create-table-pacientes.sql
@@ -1,0 +1,19 @@
+create table pacientes(
+
+    id bigint not null auto_increment,
+    nome varchar(100) not null,
+    email varchar(100) not null unique,
+    cpf varchar(14) not null unique,
+    logradouro varchar(100) not null,
+    bairro varchar(100) not null,
+    cep varchar(9) not null,
+    complemento varchar(100),
+    numero varchar(20),
+    uf char(2) not null,
+    cidade varchar(100) not null,
+    telefone varchar(20) not null,
+    ativo tinyint not null,
+
+    primary key(id)
+
+);


### PR DESCRIPTION
### feat: Implementa CRUD de Paciente e padronizacoes da API

## O quê?
- **Funcionalidades de Paciente:**
    - Criação da entidade `Paciente`, seus `records` (DTOs para cadastro, listagem, atualização) e `PacienteRepository`.
    - Implementação completa dos endpoints de CRUD para `Paciente` (Cadastro `POST`, Listagem `GET`, Atualização `PUT`, Exclusão Lógica `DELETE`).
- **Padronizações da API:**
    - Padronização dos retornos HTTP utilizando `ResponseEntity` nos controladores (`MedicoController` e `PacienteController`).
    - Adição de endpoint para detalhamento de médico por ID (`GET /{id}`).

## Por quê?
- **CRUD de Paciente:** Adicionar a capacidade de gerenciar informações de pacientes no sistema, expandindo as funcionalidades da aplicação. A exclusão lógica garante a integridade dos dados e o histórico.
- **Padronizações da API:** Melhorar a consistência e a clareza das respostas da API, facilitando o consumo por outras aplicações e a manutenção do código. O detalhamento por ID aprimora a capacidade de consulta.

## Obs:
- Certificar-se de que a migração `V4__create-table-pacientes.sql` foi aplicada corretamente no ambiente de destino.
- Os CPFs foram validados usando `@CPF` do Hibernate Validator.
- Verificar o comportamento dos endpoints no Insomnia após o merge.
- Atenção a possíveis conflitos, especialmente nos arquivos de controller, devido às sobreposições de commits de padronização/detalhamento entre as branches (se o mesmo trabalho foi feito em paralelo em `feature/medico`).
