### PR TITLE
test(consultas): Adiciona teste de integração para agendamento de con…

### DIFF
--- a/src/test/java/com/vollmed/api/controllers/ConsultaControllerTest.java
+++ b/src/test/java/com/vollmed/api/controllers/ConsultaControllerTest.java
@@ -1,0 +1,86 @@
+package com.vollmed.api.controllers;
+
+import com.vollmed.api.domain.consulta.AgendaDeConsultas;
+import com.vollmed.api.domain.consulta.DadosAgendamentoConsulta;
+import com.vollmed.api.domain.consulta.DadosDetalhamentoConsulta;
+import com.vollmed.api.domain.medico.Especialidade;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJsonTesters;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureJsonTesters
+class ConsultaControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private JacksonTester<DadosAgendamentoConsulta> dadosAgendamentoConsultaJson;
+
+    @Autowired
+    private JacksonTester<DadosDetalhamentoConsulta> dadosDetalhamentoConsultaJson;
+
+    @MockitoBean
+    private AgendaDeConsultas agendaDeConsultas;
+
+    @Test
+    @DisplayName("Deveria devolver código http 400 quando informações estão inválidas")
+    @WithMockUser
+    void agendarConsultaCenario1() throws Exception {
+        var response = mvc
+                .perform(post("/consultas"))
+                .andReturn().getResponse();
+
+        assertThat(response.getStatus())
+                .isEqualTo(HttpStatus.BAD_REQUEST.value());
+
+    }
+
+    @Test
+    @DisplayName("Deveria devolver código http 200 quando informações estão validas")
+    @WithMockUser
+    void agendarConsultaCenario2() throws Exception {
+        var data = LocalDateTime.now().plusHours(1);
+        var especialidade = Especialidade.CARDIOLOGIA;
+
+        var dadosDetalhamentoConsulta = new DadosDetalhamentoConsulta(null, 2l, 5l, data);
+        when(agendaDeConsultas.agendarConsulta(any())).thenReturn(dadosDetalhamentoConsulta);
+
+        var response = mvc
+                .perform(
+                        post("/consultas")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(dadosAgendamentoConsultaJson.write(
+                                        new DadosAgendamentoConsulta(2l, 5l, data, especialidade)
+                                ).getJson())
+                )
+                .andReturn().getResponse();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+
+        var jsonEsperado = dadosDetalhamentoConsultaJson.write(
+                dadosDetalhamentoConsulta
+        ).getJson();
+
+        assertThat(response.getContentAsString()).isEqualTo(jsonEsperado);
+    }
+
+}


### PR DESCRIPTION
### test(consultas): Adiciona testes de integração para o ConsultaController

## O quê?
- **Testes de Integração para `ConsultaController`:**
    - Adição de testes de integração para o `ConsultaController` utilizando `MockMvc`.
    - Implementação de cenários de teste para o agendamento de consultas (`POST /consultas`):
        - Cenário 1: Verifica o retorno `HTTP 400 Bad Request` quando informações inválidas (corpo vazio) são enviadas.
        - Cenário 2: Verifica o retorno `HTTP 200 OK` (ou `201 Created`, dependendo do seu controller) e o corpo da resposta quando informações válidas são enviadas.
    - Utilização de `JacksonTester` para simular requisições com corpos JSON e comparar com as respostas esperadas.
    - Atualização da anotação de mock de `@MockBean` para `@MockitoBean` para alinhamento com as versões mais recentes do Spring Boot.

## Por quê?
- **Garantia de Qualidade:** Assegurar que o `ConsultaController` funciona conforme o esperado, protegendo contra regressões em futuras alterações.
- **Robustez da API:** Verificar que a API retorna os códigos de status HTTP corretos e os corpos de resposta esperados para diferentes cenários de agendamento de consultas.
- **Manutenibilidade:** Manter o código de teste atualizado com as melhores práticas e anotações do Spring Boot.

## Observação:
- Os testes rodam com um perfil de teste (`@SpringBootTest` e `application-test.properties`).
- O serviço `AgendaDeConsultas` foi mockado (`@MockitoBean`) para isolar o teste do controller da lógica de serviço e do banco de dados.
- O `@WithMockUser` é usado para simular um usuário autenticado e permitir que o teste passe pelo filtro de segurança.